### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "^5.5",
-        "illuminate/support": "^5.5",
+        "illuminate/database": "5.5.*",
+        "illuminate/support": "5.5.*",
         "laravel/framework": "^5.5.22",
         "ramsey/uuid": "^3.7"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.

Also i find it weird that you require illuminate components plus the entire framework as a dependency. Better to pick any one of them. 