### PR TITLE
add getIdAttribute method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ UUIDs are only stored as binary in the database. You can however use a textual v
 ```php
 $model = MyModel::create();
 
-dump($model->uuid_text); // "6dae40fa-cae0-11e7-80b6-8c85901eed2e" 
+dump($model->id); // "6dae40fa-cae0-11e7-80b6-8c85901eed2e"
+dump($model->uuid_text); // "6dae40fa-cae0-11e7-80b6-8c85901eed2e"
 ```
 
 If you want to set a specific UUID before creating a model, that's also possible.

--- a/src/HasUuidPrimaryKey.php
+++ b/src/HasUuidPrimaryKey.php
@@ -4,6 +4,11 @@ namespace Spatie\BinaryUuid;
 
 trait HasUuidPrimaryKey
 {
+    public function getIdAttribute()
+    {
+        return $this->uuid_text;
+    }
+    
     public function getKeyName()
     {
         return 'uuid';


### PR DESCRIPTION
This allows to continue to use the `id` attribute as usually but will return the `uuid_text` attribute.

`$user->id` will be the same as `$user->uuid_text`