### PR TITLE
add getRouteKey method

### DIFF
--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -91,8 +91,8 @@ trait HasBinaryUuid
         return $this->newQueryWithoutScopes()->whereKey(base64_decode($id));
     }
     
-    public function getRouteKey()
+    public function getRouteKeyName()
     {
-        return $this->uuid_text;
+        return 'uuid_text';
     }
 }

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -90,4 +90,9 @@ trait HasBinaryUuid
     {
         return $this->newQueryWithoutScopes()->whereKey(base64_decode($id));
     }
+    
+    public function getRouteKey()
+    {
+        return $this->uuid_text;
+    }
 }

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -90,7 +90,7 @@ trait HasBinaryUuid
     {
         return $this->newQueryWithoutScopes()->whereKey(base64_decode($id));
     }
-    
+
     public function getRouteKeyName()
     {
         return 'uuid_text';

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -124,12 +124,12 @@ class HasBinaryUuidTest extends TestCase
     public function it_generates_valid_routes()
     {
         $uuid = Uuid::uuid1();
-        $this->createModel($uuid);
+        $model = $this->createModel($uuid);
 
         app('router')->get('uuid-test/{model}')->name('uuid-test');
 
         $expected = "http://localhost/uuid-test/$uuid";
-        $actual = route('uuid-test', $uuid);
+        $actual = route('uuid-test', $model);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -120,6 +120,20 @@ class HasBinaryUuidTest extends TestCase
         $this->assertEquals($encodeUuid, $decodedUuid);
     }
 
+    /** @test */
+    public function it_generates_valid_routes()
+    {
+        $uuid = Uuid::uuid1();
+        $this->createModel($uuid);
+
+        app('router')->get('uuid-test/{model}')->name('uuid-test');
+
+        $expected = "http://localhost/uuid-test/$uuid";
+        $actual = route('uuid-test', $uuid);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     private function createModel(string $uuid, $relationUuid = null): TestModel
     {
         $model = new TestModel();

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -124,14 +124,12 @@ class HasBinaryUuidTest extends TestCase
     public function it_generates_valid_routes()
     {
         $uuid = Uuid::uuid1();
+
         $model = $this->createModel($uuid);
 
         app('router')->get('uuid-test/{model}')->name('uuid-test');
 
-        $expected = "http://localhost/uuid-test/$uuid";
-        $actual = route('uuid-test', $model);
-
-        $this->assertEquals($expected, $actual);
+        $this->assertContains("/uuid-test/{$uuid}", route('uuid-test', $model));
     }
 
     private function createModel(string $uuid, $relationUuid = null): TestModel


### PR DESCRIPTION
Currently passing models to the `route` method to generate a url will result in a malformed url as the binary uuid will be used.

```php
// call
route('account.announcements.show', App\Announcement::first())

// now
http://app.dev/account/announcements/%11%E7%D5%8A%C41%96%D4%97%8D%FE%00h%82%C2%01

// new
http://app.dev/account/announcements/c43196d4-d58a-11e7-978d-fe006882c201
```