### PR TITLE
Add proper support for json_encode

### DIFF
--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -71,6 +71,11 @@ trait HasBinaryUuid
         return Uuid::fromBytes($binaryUuid)->toString();
     }
 
+    public function toArray()
+    {
+        return array_merge(parent::toArray(), [$this->getKeyName() => $this->uuid_text]);
+    }
+
     public function getUuidTextAttribute(): string
     {
         return static::decodeUuid($this->{$this->getKeyName()});

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -148,7 +148,7 @@ class HasBinaryUuidTest extends TestCase
     {
         $model = TestModel::create();
 
-        $json = json_encode($model->toJson());
+        $json = json_encode($model);
 
         $this->assertContains($model->uuid_text, $json);
         $this->assertNotContains($model->uuid, $json);

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -132,6 +132,28 @@ class HasBinaryUuidTest extends TestCase
         $this->assertContains("/uuid-test/{$uuid}", route('uuid-test', $model));
     }
 
+    /** @test */
+    public function it_serialises_the_model_correctly()
+    {
+        $model = TestModel::create();
+
+        $json = $model->toJson();
+
+        $this->assertContains($model->uuid_text, $json);
+        $this->assertNotContains($model->uuid, $json);
+    }
+
+    /** @test */
+    public function it_serialises_the_model_correctly_with_json_encode()
+    {
+        $model = TestModel::create();
+
+        $json = json_encode($model->toJson());
+
+        $this->assertContains($model->uuid_text, $json);
+        $this->assertNotContains($model->uuid, $json);
+    }
+
     private function createModel(string $uuid, $relationUuid = null): TestModel
     {
         $model = new TestModel();


### PR DESCRIPTION
This PR fixes a `json_encode` issue by replacing the binary UUID with the textual one when serialising a model.