### PR TITLE
Allow for Route Model Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class TestModel extends Model
 }
 ```
 
-If don't like the primary key named `uuid` you can leave off the `HasUuidPrimaryKey` trait and manually specify `$primaryKey`. Don't forget set `$incrementing` to false.
+If don't like the primary key named `uuid` you can overwrite the `getKeyName` method to manually specify the primary key name.
 
 ```php
 use Illuminate\Database\Eloquent\Model;
@@ -58,11 +58,13 @@ use Spatie\BinaryUuid\HasBinaryUuid;
 
 class TestModel extends Model
 {
-    use HasBinaryUuid;
+    use HasBinaryUuid,
+        HasUuidPrimaryKey;
 
-    public $incrementing = false;
-    
-    public $primaryKey = 'uuid';
+    public function getKeyName()
+    {
+        return 'uuid';
+    }
 }
 ```
 

--- a/src/HasUuidPrimaryKey.php
+++ b/src/HasUuidPrimaryKey.php
@@ -13,4 +13,9 @@ trait HasUuidPrimaryKey
     {
         return false;
     }
+
+    public function resolveRouteBinding($value)
+    {
+        return $this->withUuid($value)->first();
+    }
 }

--- a/tests/Feature/CreatesModel.php
+++ b/tests/Feature/CreatesModel.php
@@ -20,5 +20,4 @@ trait CreatesModel
 
         return $model;
     }
-    
 }

--- a/tests/Feature/CreatesModel.php
+++ b/tests/Feature/CreatesModel.php
@@ -20,4 +20,5 @@ trait CreatesModel
 
         return $model;
     }
+    
 }

--- a/tests/Feature/CreatesModel.php
+++ b/tests/Feature/CreatesModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\BinaryUuid\Test\Feature;
+
+use Spatie\BinaryUuid\Test\TestModel;
+
+trait CreatesModel
+{
+    private function createModel(string $uuid, $relationUuid = null): TestModel
+    {
+        $model = new TestModel();
+
+        $model->uuid_text = $uuid;
+
+        if ($relationUuid) {
+            $model->relation_uuid = TestModel::encodeUuid($relationUuid);
+        }
+
+        $model->save();
+
+        return $model;
+    }
+}

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\BinaryUuid\Test\Unit;
+namespace Spatie\BinaryUuid\Test\Feature;
 
 use Ramsey\Uuid\Uuid;
 use Spatie\BinaryUuid\Test\TestCase;

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -8,6 +8,8 @@ use Spatie\BinaryUuid\Test\TestModel;
 
 class HasBinaryUuidTest extends TestCase
 {
+    use CreatesModel;
+
     /** @test */
     public function it_generates_the_uuid_on_save()
     {
@@ -152,20 +154,5 @@ class HasBinaryUuidTest extends TestCase
 
         $this->assertContains($model->uuid_text, $json);
         $this->assertNotContains($model->uuid, $json);
-    }
-
-    private function createModel(string $uuid, $relationUuid = null): TestModel
-    {
-        $model = new TestModel();
-
-        $model->uuid_text = $uuid;
-
-        if ($relationUuid) {
-            $model->relation_uuid = TestModel::encodeUuid($relationUuid);
-        }
-
-        $model->save();
-
-        return $model;
     }
 }

--- a/tests/Feature/HasUuidPrimaryKeyTest.php
+++ b/tests/Feature/HasUuidPrimaryKeyTest.php
@@ -38,7 +38,7 @@ class HasUuidPrimaryKeyTest extends TestCase
 
         $this->get("uuid-test/{$uuid->toString()}")
             ->assertJson([
-                'uuid' => $uuid
+                'uuid' => $uuid,
             ]);
     }
 }

--- a/tests/Feature/HasUuidPrimaryKeyTest.php
+++ b/tests/Feature/HasUuidPrimaryKeyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\BinaryUuid\Test\Feature;
+
+use Ramsey\Uuid\Uuid;
+use Spatie\BinaryUuid\Test\TestCase;
+use Spatie\BinaryUuid\Test\TestModel;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+
+class HasUuidPrimaryKeyTest extends TestCase
+{
+    use CreatesModel;
+
+    /** @test */
+    public function it_resolves_route_binding()
+    {
+        $uuid = Uuid::uuid1();
+        $this->createModel($uuid);
+
+        $resolvedModel = (new TestModel())->resolveRouteBinding($uuid);
+
+        $this->assertEquals((string) $uuid, $resolvedModel->uuid_text);
+    }
+
+    /** @test */
+    public function laravel_resolves_route_binding_correctly()
+    {
+        $uuid = Uuid::uuid1();
+        $this->createModel($uuid);
+
+        app('router')
+            ->middleware(SubstituteBindings::class)
+            ->group(function () {
+                app('router')->get('uuid-test/{model}', function (TestModel $model) {
+                    return $model;
+                });
+            });
+
+        $this->get("uuid-test/{$uuid->toString()}")
+            ->assertJson([
+                'uuid' => $uuid
+            ]);
+    }
+}


### PR DESCRIPTION
Provides a fix for #32 and allows for Laravel to automagically bind the model using the binary uuid.