### PR TITLE
Prevent decoding the uuid when the model does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "illuminate/queue": "~5.5.28|~5.6.0",
         "ramsey/uuid": "^3.7"
     },

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -73,11 +73,19 @@ trait HasBinaryUuid
 
     public function toArray()
     {
+        if (! $this->exists) {
+            return parent::toArray();
+        }
+
         return array_merge(parent::toArray(), [$this->getKeyName() => $this->uuid_text]);
     }
 
-    public function getUuidTextAttribute(): string
+    public function getUuidTextAttribute(): ?string
     {
+        if (! $this->exists) {
+            return null;
+        }
+
         return static::decodeUuid($this->{$this->getKeyName()});
     }
 

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -155,4 +155,13 @@ class HasBinaryUuidTest extends TestCase
         $this->assertContains($model->uuid_text, $json);
         $this->assertNotContains($model->uuid, $json);
     }
+
+    /** @test */
+    public function it_prevents_decoding_the_uuid_when_the_model_does_not_exist()
+    {
+        $model = new TestModel;
+
+        $this->assertEmpty($model->toArray());
+        $this->assertNull($model->uuid_text);
+    }
 }


### PR DESCRIPTION
This resolves issue https://github.com/spatie/laravel-binary-uuid/issues/39.