### PR TITLE
[#47] toArray on HasBinaryUuid conditionally adds model key

### DIFF
--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -77,7 +77,13 @@ trait HasBinaryUuid
             return parent::toArray();
         }
 
-        return array_merge(parent::toArray(), [$this->getKeyName() => $this->uuid_text]);
+        $data = parent::toArray();
+
+        if (isset($data[$this->getKeyName()])) {
+            $data[$this->getKeyName()] = $this->uuid_text;
+        }
+
+        return $data;
     }
 
     public function getUuidTextAttribute(): ?string

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -164,4 +164,14 @@ class HasBinaryUuidTest extends TestCase
         $this->assertEmpty($model->toArray());
         $this->assertNull($model->uuid_text);
     }
+
+    /** @test */
+    public function it_prevents_decoding_model_key_when_it_is_not_included_in_attributes()
+    {
+        $model = TestModel::create();
+        $model->setRawAttributes(['test' => 'test']);
+        $array = $model->toArray();
+
+        $this->assertFalse(isset($array[$model->getKeyName()]));
+    }
 }


### PR DESCRIPTION
Checks if the model key was actually included in the attributes and only adds the decoded version when it is included.

This shouldn't break anything but fix serializing query results where the model key was not included