### PR TITLE
Adding dynamic accessors and mutators from $uuidAttributes and customising uuid text attribute suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ class TestModel extends Model
     use HasBinaryUuid;
     
     /**
+     * The suffix for the uuid text attribute 
+     *
+     * @var
+     */
+    protected $uuidTextAttribSuffix = '_str';
+    
+    /**
      * The binary UUID attributes that should be converted to text.
      *
      * @var array
@@ -88,7 +95,7 @@ class TestModel extends Model
 }
 ```
 
-In your JSON you will see `uuid` and `country_uuid` in their textual representation. If you're also making use of composite primary keys, the above work well enough too. Just include your keys in the `$uuidAttributes` array or override the `getKeyName` method on your model and return your composite primary keys as an array of keys.
+In your JSON you will see `uuid` and `country_uuid` in their textual representation. If you're also making use of composite primary keys, the above works well enough too. Just include your keys in the `$uuidAttributes` array or override the `getKeyName()` method on your model and return your composite primary keys as an array of keys.
 
 #### A note on the `uuid` blueprint method
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ class TestModel extends Model
     
     /**
      * The suffix for the uuid text attribute 
-     *
+     * by default its '_text'
+     * 
      * @var
      */
     protected $uuidTextAttribSuffix = '_str';

--- a/README.md
+++ b/README.md
@@ -78,20 +78,19 @@ class TestModel extends Model
     
     /**
      * The suffix for the uuid text attribute 
-     * by default its '_text'
+     * by default this is '_text'
      * 
      * @var
      */
-    protected $uuidTextAttribSuffix = '_str';
+    protected $uuidSuffix = '_str';
     
     /**
      * The binary UUID attributes that should be converted to text.
      *
      * @var array
      */
-    protected $uuidAttributes = [
-        'uuid',
-        'country_uuid', // foreign key
+    protected $uuids = [
+        'country_uuid' // foreign key
     ];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ class TestModel extends Model
      * @var array
      */
     protected $uuids = [
-        'country_uuid' // foreign key
+        'country_uuid' // foreign or related key
     ];
 }
 ```
 
-In your JSON you will see `uuid` and `country_uuid` in their textual representation. If you're also making use of composite primary keys, the above works well enough too. Just include your keys in the `$uuidAttributes` array or override the `getKeyName()` method on your model and return your composite primary keys as an array of keys.
+In your JSON you will see `uuid` and `country_uuid` in their textual representation. If you're also making use of composite primary keys, the above works well enough too. Just include your keys in the `$uuids` array or override the `getKeyName()` method on your model and return your composite primary keys as an array of keys. You can also customize the UUID text attribute suffix name. In the code above, instead of '\_text' it's '\_str'.
 
 #### A note on the `uuid` blueprint method
 

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -94,7 +94,7 @@ trait HasBinaryUuid
 
     public function getRelatedBinaryKeyName($attribute)
     {
-        $suffix = $this->getUuidTextAttributeSuffix();
+        $suffix = $this->getUuidSuffix();
 
         return preg_match("/(?:uu)?id/i", $attribute) !== null ? "{$attribute}{$suffix}" : $attribute;
     }

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -96,7 +96,7 @@ trait HasBinaryUuid
     {
         $suffix = $this->getUuidSuffix();
 
-        return preg_match('/(?:uu)?id/i', $attribute) !== null ? "{$attribute}{$suffix}" : $attribute;
+        return preg_match('/(?:uu)?id/i', $attribute) ? "{$attribute}{$suffix}" : $attribute;
     }
 
     public function getAttribute($key)
@@ -155,16 +155,24 @@ trait HasBinaryUuid
 
     public function getUuidTextAttribute(): ?string
     {
-        if (! $this->exists) {
+        $key = $this->getKeyName();
+
+        if (! $this->exists || is_array($key)) {
             return null;
         }
 
-        return static::decodeUuid($this->{$this->getKeyName()});
+        return static::decodeUuid($this->{$key});
     }
 
     public function setUuidTextAttribute(string $uuid)
     {
-        $this->{$this->getKeyName()} = static::encodeUuid($uuid);
+        $key = $this->getKeyName();
+
+        if (is_array($key)) {
+            return;
+        }
+
+        $this->{$key} = static::encodeUuid($uuid);
     }
 
     public function getQueueableId()

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Builder;
 
 trait HasBinaryUuid
 {
-
     protected static function bootHasBinaryUuid()
     {
         static::creating(function (Model $model) {
@@ -71,22 +70,19 @@ trait HasBinaryUuid
 
         return Uuid::fromBytes($binaryUuid)->toString();
     }
-    
+
     public function toArray()
     {
-
         $uuidAttributes = $this->getUuidAttributes();
 
         $array = parent::toArray();
 
         // if (! $this->exists) {
-            // return $array;
+        // return $array;
         // }
 
         if (is_array($uuidAttributes)) {
-
             foreach ($uuidAttributes as $attributeKey) {
-
                 if (array_key_exists($attributeKey, $array)) {
                     $uuidKey = $this->getRelatedBinaryKeyName($attributeKey);
                     $array[$attributeKey] = $this->{$uuidKey};
@@ -99,7 +95,6 @@ trait HasBinaryUuid
 
     public function getRelatedBinaryKeyName($attrib)
     {
-
         $suffix = $this->getUuidTextAttributeSuffix();
 
         return "{$attrib}{$suffix}";
@@ -107,7 +102,6 @@ trait HasBinaryUuid
 
     public function getAttribute($key)
     {
-
         if (($uuidKey = $this->uuidTextAttribute($key)) && $this->{$uuidKey} !== null) {
             return static::decodeUuid($this->{$uuidKey});
         }
@@ -117,7 +111,6 @@ trait HasBinaryUuid
 
     public function setAttribute($key, $value)
     {
-
         if ($uuidKey = $this->uuidTextAttribute($key)) {
             $value = static::encodeUuid($value);
         }
@@ -127,7 +120,7 @@ trait HasBinaryUuid
 
     protected function getUuidTextAttributeSuffix()
     {
-        return (property_exists($this, 'uuidTextAttribSuffix'))? $this->uuidTextAttribSuffix : '_text';
+        return (property_exists($this, 'uuidTextAttribSuffix')) ? $this->uuidTextAttribSuffix : '_text';
     }
 
     protected function uuidTextAttribute($key)
@@ -138,7 +131,7 @@ trait HasBinaryUuid
         $offset = -(strlen($suffix));
 
         if (is_string($attribute_s)) {
-            $attribute_s = [ $attribute_s ];
+            $attribute_s = [$attribute_s];
         }
 
         if (substr($key, $offset) == $suffix && in_array(($uuidKey = substr($key, 0, $offset)), $attribute_s)) {
@@ -157,17 +150,16 @@ trait HasBinaryUuid
             $uuidAttributes = $this->uuidAttributes === null ? [] : $this->uuidAttributes;
         }
 
-        $key = $this->getKeyName();// ! composite primary keys will return an array
+        $key = $this->getKeyName(); // ! composite primary keys will return an array
 
         if (is_string($key)) {
-            $uuidAttributes = array_merge($uuidAttributes, [ $key ]); 
-        } else if (is_array($key)) {
+            $uuidAttributes = array_merge($uuidAttributes, [$key]); 
+        } elseif (is_array($key)) {
             $uuidAttributes = array_merge($uuidAttributes, $key);
         }
 
         return $uuidAttributes;
     }
-    
 
     public function getUuidTextAttribute(): ?string
     {

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -125,7 +125,6 @@ trait HasBinaryUuid
 
     protected function uuidTextAttribute($key)
     {
-
         $attribute_s = $this->getKeyName();
         $suffix = $this->getUuidTextAttributeSuffix();
         $offset = -(strlen($suffix));
@@ -143,7 +142,6 @@ trait HasBinaryUuid
 
     public function getUuidAttributes()
     {
-
         $uuidAttributes = [];
 
         if (property_exists($this, 'uuidAttributes')) {
@@ -153,7 +151,7 @@ trait HasBinaryUuid
         $key = $this->getKeyName(); // ! composite primary keys will return an array
 
         if (is_string($key)) {
-            $uuidAttributes = array_merge($uuidAttributes, [$key]); 
+            $uuidAttributes = array_merge($uuidAttributes, [$key]);
         } elseif (is_array($key)) {
             $uuidAttributes = array_merge($uuidAttributes, $key);
         }

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -96,7 +96,7 @@ trait HasBinaryUuid
     {
         $suffix = $this->getUuidSuffix();
 
-        return preg_match("/(?:uu)?id/i", $attribute) !== null ? "{$attribute}{$suffix}" : $attribute;
+        return preg_match('/(?:uu)?id/i', $attribute) !== null ? "{$attribute}{$suffix}" : $attribute;
     }
 
     public function getAttribute($key)

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -79,9 +79,9 @@ trait HasBinaryUuid
 
         $array = parent::toArray();
 
-        if (! $this->exists) {
-            return $array;
-        }
+        // if (! $this->exists) {
+            // return $array;
+        // }
 
         if (is_array($uuidAttributes)) {
 

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -74,20 +74,19 @@ trait HasBinaryUuid
     
     public function toArray()
     {
-			
+
         $uuidAttributes = $this->getUuidAttributes();
-        
+
         $array = parent::toArray();
-          
+
         if (! $this->exists) {
             return $array;
         }
-	    
-	    
+
         if (is_array($uuidAttributes)) {
 
             foreach ($uuidAttributes as $attributeKey) {
-			
+
                 if (array_key_exists($attributeKey, $array)) {
                     $uuidKey = $this->getRelatedBinaryKeyName($attributeKey);
                     $array[$attributeKey] = $this->{$uuidKey};
@@ -97,7 +96,7 @@ trait HasBinaryUuid
 
         return $array;
     }
-	
+
     public function getRelatedBinaryKeyName($attrib)
     {
 
@@ -105,7 +104,7 @@ trait HasBinaryUuid
 
         return "{$attrib}{$suffix}";
     }
-    
+
     public function getAttribute($key)
     {
 
@@ -115,9 +114,10 @@ trait HasBinaryUuid
 
         return parent::getAttribute($key);
     }
-    
+
     public function setAttribute($key, $value)
     {
+
         if ($uuidKey = $this->uuidTextAttribute($key)) {
             $value = static::encodeUuid($value);
         }
@@ -156,7 +156,7 @@ trait HasBinaryUuid
         if (property_exists($this, 'uuidAttributes')) {
             $uuidAttributes = $this->uuidAttributes === null ? [] : $this->uuidAttributes;
         }
-        
+
         $key = $this->getKeyName();// ! composite primary keys will return an array
 
         if (is_string($key)) {

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -134,7 +134,7 @@ trait HasBinaryUuid
             return $uuidKey;
         }
 
-        return null;
+        return false;
     }
 
     public function getUuidAttributes()

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -81,6 +81,23 @@ class HasBinaryUuidTest extends TestCase
     }
 
     /** @test */
+    public function it_decodes_columns_besides_primary_uuid_when_turned_to_array()
+    {
+        $uuid = Uuid::uuid1();
+        $relationUuid = Uuid::uuid1();
+
+        $model = $this->createModel($uuid, $relationUuid);
+
+        $modelArray = $model->toArray();
+
+        $this->assertNotNull($model);
+        $this->assertCount(2, $modelArray);
+        $this->assertTrue(array_key_exists('relation_uuid', $modelArray));
+        $this->assertTrue(array_key_exists('uuid', $modelArray));
+        $this->assertEquals($modelArray['relation_uuid'], $model->relation_uuid_text);
+    }
+
+    /** @test */
     public function it_can_query_multiple_relations_with_scope()
     {
         $relationUuid1 = Uuid::uuid1();

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -97,6 +97,22 @@ class HasBinaryUuidTest extends TestCase
     }
 
     /** @test */
+    public function it_should_use_custom_suffix_when_specified()
+    {
+        $uuid = Uuid::uuid1();
+
+        $model = $this->createModel($uuid);
+
+        $model->setUuidSuffix('_str');
+
+        $modelArray = $model->toArray();
+
+        $this->assertNotNull($model);
+        $this->assertTrue(array_key_exists('uuid', $modelArray));
+        $this->assertEquals($modelArray['uuid'], $model->uuid_str);
+    }
+
+    /** @test */
     public function it_can_query_multiple_relations_with_scope()
     {
         $relationUuid1 = Uuid::uuid1();

--- a/tests/Feature/HasBinaryUuidTest.php
+++ b/tests/Feature/HasBinaryUuidTest.php
@@ -81,7 +81,7 @@ class HasBinaryUuidTest extends TestCase
     }
 
     /** @test */
-    public function it_decodes_columns_besides_primary_uuid_when_turned_to_array()
+    public function it_decodes_columns_besides_primary_uuid_when_turned_to_an_array()
     {
         $uuid = Uuid::uuid1();
         $relationUuid = Uuid::uuid1();
@@ -91,9 +91,8 @@ class HasBinaryUuidTest extends TestCase
         $modelArray = $model->toArray();
 
         $this->assertNotNull($model);
-        $this->assertCount(2, $modelArray);
+        $this->assertCount(4, $modelArray);
         $this->assertTrue(array_key_exists('relation_uuid', $modelArray));
-        $this->assertTrue(array_key_exists('uuid', $modelArray));
         $this->assertEquals($modelArray['relation_uuid'], $model->relation_uuid_text);
     }
 

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -9,5 +9,11 @@ class TestModel extends Model
 {
     use HasBinaryUuid;
 
+    protected $uuids = [
+        'relation_uuid'
+    ];
+
+    protected $uuidSuffix = '_text';
+
     protected $table = 'test';
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -16,4 +16,9 @@ class TestModel extends Model
     protected $uuidSuffix = '_text';
 
     protected $table = 'test';
+
+    public function setUuidSuffix($suffix = '_text')
+    {
+        $this->uuidSuffix = $suffix;
+    }
 }

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -10,7 +10,7 @@ class TestModel extends Model
     use HasBinaryUuid;
 
     protected $uuids = [
-        'relation_uuid'
+        'relation_uuid',
     ];
 
     protected $uuidSuffix = '_text';


### PR DESCRIPTION
This PR references this [PR](https://github.com/spatie/laravel-binary-uuid/pull/35) by @westphalen and also this [issue](https://github.com/spatie/laravel-binary-uuid/issues/45) #45 and #33 . It also makes the default `uuid` text attribute suffix customizable with support for composite keys without breaking original code. Details are on `README.md` file on this PR branch.

Thanks in anticipation.