### PR TITLE
Change SQLite Uuid type from "binary" to "blob"

### DIFF
--- a/src/SQLiteGrammar.php
+++ b/src/SQLiteGrammar.php
@@ -9,6 +9,6 @@ class SQLiteGrammar extends IlluminateSQLiteGrammar
 {
     protected function typeUuid(Fluent $column)
     {
-        return 'binary(16)';
+        return 'blob(256)';
     }
 }


### PR DESCRIPTION
SQLite doesn't support the "binary" data type as specified in the SQLiteGrammar file, changing this to blob allows SQLite to work as intended.

See: https://github.com/spatie/laravel-binary-uuid/issues/57
