### PR TITLE
Connect the codecoverage to scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,3 +17,7 @@ checks:
         fix_identation_4spaces: true
         fix_doc_comments: true
 
+tools:
+    external_code_coverage:
+        timeout: 600
+        runs: 4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-binary-uuid.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-binary-uuid)
 [![Build Status](https://img.shields.io/travis/spatie/laravel-binary-uuid/master.svg?style=flat-square)](https://travis-ci.org/spatie/laravel-binary-uuid)
+[![Code coverage](https://scrutinizer-ci.com/g/spatie/laravel-binary-uuid/badges/coverage.png)](https://scrutinizer-ci.com/g/spatie/laravel-binary-uuid)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-binary-uuid.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-binary-uuid)
 [![StyleCI](https://styleci.io/repos/110949385/shield?branch=master)](https://styleci.io/repos/110949385)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-binary-uuid.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-binary-uuid)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "^3.5|~3.6.0|~3.7.0",
-        "phpunit/phpunit": "^6.5|^7.0"
+        "phpunit/phpunit": "^6.5|^7.0",
+        "scrutinizer/ocular": "^1.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have configured the code coverage report from scrutinizer and add the badge to the readme file.

It has 3 steps
1. Add scrutinizer/ocular
2. Allow remote code coverage in .scrutinizer.yml
3. Add the badge to the readme