### PR TITLE
Fix reliance on static factory [Issue #84]

### DIFF
--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -5,8 +5,8 @@ namespace Spatie\BinaryUuid;
 use App;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
-use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Illuminate\Database\Eloquent\Model;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
 
 trait HasBinaryUuid
 {

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -4,6 +4,7 @@ namespace Spatie\BinaryUuid;
 
 use App;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Illuminate\Database\Eloquent\Model;
 
@@ -26,8 +27,8 @@ trait HasBinaryUuid
             return static::scopeWithUuidRelation($builder, $uuid, $field);
         }
 
-        if ($uuid instanceof Uuid) {
-            $uuid = (string) $uuid;
+        if ($uuid instanceof UuidInterface) {
+            $uuid = $uuid->toString();
         }
 
         $uuid = (array) $uuid;
@@ -39,8 +40,8 @@ trait HasBinaryUuid
 
     public static function scopeWithUuidRelation(Builder $builder, $uuid, string $field): Builder
     {
-        if ($uuid instanceof Uuid) {
-            $uuid = (string) $uuid;
+        if ($uuid instanceof UuidInterface) {
+            $uuid = $uuid->toString();
         }
 
         $uuid = (array) $uuid;
@@ -61,7 +62,7 @@ trait HasBinaryUuid
             return $uuid;
         }
 
-        if (! $uuid instanceof Uuid) {
+        if (! $uuid instanceof UuidInterface) {
             $uuid = Uuid::fromString($uuid);
         }
 

--- a/src/HasBinaryUuid.php
+++ b/src/HasBinaryUuid.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\BinaryUuid;
 
+use App;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Illuminate\Database\Eloquent\Model;
 
 trait HasBinaryUuid
@@ -63,7 +65,10 @@ trait HasBinaryUuid
             $uuid = Uuid::fromString($uuid);
         }
 
-        return $uuid->getBytes();
+        /** @var OrderedTimeCodec $codec */
+        $codec = App::make(OrderedTimeCodec::class);
+
+        return $codec->encodeBinary($uuid);
     }
 
     public static function decodeUuid(string $binaryUuid): string
@@ -72,7 +77,10 @@ trait HasBinaryUuid
             return $binaryUuid;
         }
 
-        return Uuid::fromBytes($binaryUuid)->toString();
+        /** @var OrderedTimeCodec $codec */
+        $codec = App::make(OrderedTimeCodec::class);
+
+        return $codec->decodeBytes($binaryUuid)->toString();
     }
 
     public function toArray()

--- a/src/UuidServiceProvider.php
+++ b/src/UuidServiceProvider.php
@@ -21,7 +21,9 @@ class UuidServiceProvider extends ServiceProvider
 
         $connection->setSchemaGrammar($this->createGrammarFromConnection($connection));
 
-        $this->optimizeUuids();
+        $this->app->singleton(OrderedTimeCodec::class, function () {
+            return new OrderedTimeCodec((new UuidFactory)->getUuidBuilder());
+        });
     }
 
     protected function createGrammarFromConnection(Connection $connection): Grammar
@@ -46,16 +48,5 @@ class UuidServiceProvider extends ServiceProvider
         $grammar->setTablePrefix($queryGrammar->getTablePrefix());
 
         return $grammar;
-    }
-
-    protected function optimizeUuids()
-    {
-        $factory = new UuidFactory();
-
-        $codec = new OrderedTimeCodec($factory->getUuidBuilder());
-
-        $factory->setCodec($codec);
-
-        Uuid::setFactory($factory);
     }
 }

--- a/src/UuidServiceProvider.php
+++ b/src/UuidServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Spatie\BinaryUuid;
 
 use Exception;
-use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactory;
 use Illuminate\Database\Connection;
 use Illuminate\Support\ServiceProvider;


### PR DESCRIPTION
Addresses https://github.com/spatie/laravel-binary-uuid/issues/84

Fixes reliance on Uuid static factory 
- Boots a singleton OrderedTimeCodec in service provider
- Resolves an instance of the codec for en/decoding UUID
  to/from optimised binary

Also change some type comparisons of Uuid objects from Uuid to UuidInterface